### PR TITLE
feat(backend): automatically fetch air data from gios

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ php artisan migrate:fresh --seed
 php artisan serve --host=0.0.0.0 --port=8000
 ```
 
-The application will be available at `http://localhost:8000`.
+API will be available at `http://localhost:8000`.
 
 8. **Run the React development server (frontend):**
 
@@ -69,3 +69,19 @@ The application will be available at `http://localhost:8000`.
 bun install
 bun run dev
 ```
+
+Frontend will be available at `http://localhost:8000`.
+
+9. **(Optional) Automatically run scheduled tasks:**
+
+The server is set up to perform certain actions every so often,
+but in order for them to execute,
+the scheduler and queue must run in the background:
+
+```sh
+php artisan schedule:work &
+php artisan queue:work &
+```
+
+> After each change to the dependent code,
+> it must be restarted for the changes to take effect.

--- a/app/Jobs/DeleteOldAirPollutionData.php
+++ b/app/Jobs/DeleteOldAirPollutionData.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\AirPollutionHistoricalData;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Carbon;
+
+class DeleteOldAirPollutionData implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Execute the job to delete historical data older than 3 days.
+     */
+    public function handle(): void
+    {
+        $cutoffDate = Carbon::now()->subDays(3);
+        AirPollutionHistoricalData::where('created_at', '<', $cutoffDate)->delete();
+    }
+}

--- a/app/Jobs/StoreCurrentAirPollution.php
+++ b/app/Jobs/StoreCurrentAirPollution.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\AirPollutionHistoricalData;
+use App\Services\GiosApi;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class StoreCurrentAirPollution implements ShouldQueue, ShouldBeUnique
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @param  GiosApi  $giosApi
+     */
+    public function handle(GiosApi $giosApi): void
+    {
+        $stations = $giosApi->getAllStations();
+        if (empty($stations)) {
+            return;
+        }
+
+        foreach ($stations as $station) {
+            $stationId   = data_get($station, 'id');
+            $latitude    = (float) data_get($station, 'gegrLat');
+            $longitude   = (float) data_get($station, 'gegrLon');
+            $stationName = data_get($station, 'stationName');
+
+            $aqIndexData = $giosApi->getAirQualityIndex($stationId);
+            $aqIndex     = data_get($aqIndexData, 'stIndexLevel.indexLevelName');
+
+            $sensors      = $giosApi->getStationSensors($stationId) ?: [];
+            $measurements = [];
+            $pm10 = $pm25 = $no2 = $so2 = $o3 = $co = null;
+
+            foreach ($sensors as $sensor) {
+                $paramCode = data_get($sensor, 'param.paramCode');
+                $sensorId  = data_get($sensor, 'id');
+                $data      = $giosApi->getSensorData($sensorId);
+
+                // Store the full time series in JSON
+                $measurements[$paramCode] = $data['values'] ?? [];
+
+                // Parse the latest valid reading
+                if (!empty($data['values'])) {
+                    $lastValid = $this->getLatestValidValue($data['values']);
+                    $value = isset($lastValid['value']) ? (float) $lastValid['value'] : null;
+
+                    switch (strtoupper($paramCode)) {
+                        case 'PM10':
+                            $pm10 = $value;
+                            break;
+                        case 'PM2':
+                        case 'PM2.5':
+                        case 'PM25':
+                            $pm25 = $value;
+                            break;
+                        case 'NO2':
+                            $no2 = $value;
+                            break;
+                        case 'SO2':
+                            $so2 = $value;
+                            break;
+                        case 'O3':
+                            $o3 = $value;
+                            break;
+                        case 'CO':
+                            $co = $value;
+                            break;
+                    }
+                }
+            }
+
+            // Get forecasts for major pollutants
+            $forecasts = [];
+            $communeId = data_get($station, 'city.commune.communeId');
+            if ($communeId) {
+                foreach (['PM10', 'NO2', 'SO2', 'O3'] as $pollutant) {
+                    $f = $giosApi->getForecast($pollutant, (string) $communeId);
+                    if ($f !== null) {
+                        $forecasts[$pollutant] = $f;
+                    }
+                }
+            }
+
+            AirPollutionHistoricalData::create([
+                'latitude'          => $latitude,
+                'longitude'         => $longitude,
+                'station_name'      => $stationName,
+                'air_quality_index' => $aqIndex,
+                'pm10'              => $pm10,
+                'pm25'              => $pm25,
+                'no2'               => $no2,
+                'so2'               => $so2,
+                'o3'                => $o3,
+                'co'                => $co,
+                'measurements'      => $measurements,
+                'forecasts'         => $forecasts,
+            ]);
+        }
+    }
+
+    /**
+     * Get the latest valid value from the time series data.
+     *
+     * @param  array  $values
+     * @return array|null
+     */
+     private function getLatestValidValue(array $values): ?array
+     {
+         foreach ($values as $value) {
+             if (isset($value['value']) && $value['value'] !== null) {
+                 return $value;
+             }
+         }
+         return null;
+     }
+}

--- a/app/Models/AirPollutionHistoricalData.php
+++ b/app/Models/AirPollutionHistoricalData.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AirPollutionHistoricalData extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'air_pollution_historical_data';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'latitude',
+        'longitude',
+        'station_name',
+        'air_quality_index',
+        'pm10',
+        'pm25',
+        'no2',
+        'so2',
+        'o3',
+        'co',
+        'measurements',
+        'forecasts',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'latitude' => 'float',
+        'longitude' => 'float',
+        'pm10' => 'float',
+        'pm25' => 'float',
+        'no2' => 'float',
+        'so2' => 'float',
+        'o3' => 'float',
+        'co' => 'float',
+        'measurements' => 'array',
+        'forecasts' => 'array',
+    ];
+}

--- a/app/Services/GiosApi.php
+++ b/app/Services/GiosApi.php
@@ -9,6 +9,7 @@ use Exception;
 *
 * A PHP class for interacting with the air quality API provided by the
 * Chief Inspectorate of Environmental Protection (GIOŚ) in Poland.
+* https://powietrze.gios.gov.pl/pjp/content/api
 */
 class GiosApi
 {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Jobs\DeleteOldAirPollutionData;
 use App\Jobs\StoreCurrentAirPollution;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
@@ -35,4 +36,5 @@ return Application::configure(basePath: dirname(__DIR__))
         //
     })->withSchedule(function (Schedule $schedule) {
         $schedule->job(new StoreCurrentAirPollution)->everyThirtyMinutes();
+        $schedule->job(new DeleteOldAirPollutionData)->daily();
     })->create();

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Jobs\StoreCurrentAirPollution;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -31,4 +33,6 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //
+    })->withSchedule(function (Schedule $schedule) {
+        $schedule->job(new StoreCurrentAirPollution)->everyThirtyMinutes();
     })->create();


### PR DESCRIPTION
Close #165

![image](https://github.com/user-attachments/assets/069afefb-f900-4179-ad56-e73cdceec4df)

## StoreCurrentAirPollution

Scheduler tworzy job co 30 min, który jest wrzucany do kolejki i kolejka to uruchamia.

Aby to działało na serwerze musi być uruchmiony scheduler oraz kolejka w tle. Aby je uruchomić należy użyć:

```sh
php artisan schedule:work
php artisan queue:work
```

> To po prostu je uruchomi (nie w tle).

Po każdej zmianie zależnego kodu należy na nowo je uruchomić.

U mnie (z oszczędzaniem baterii) cały job trwa blisko 3 minuty, więc na tym potężnym jednordzeniowym serverze pewnie to zajmie odrobinę dłużej xD 

## DeleteOldAirPollutionData

Raz dziennie wszystkie dane historyczne starsze niż 3 dni będą usuwane.
