### PR TITLE
BE zrealizowane

### DIFF
--- a/app/Console/Commands/CheckTemperatureAlerts.php
+++ b/app/Console/Commands/CheckTemperatureAlerts.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\User;
+use App\Mail\SendMail;
+use App\Services\ImgwApiClient;
+
+class CheckTemperatureAlerts extends Command
+{
+    protected $signature = 'check:temp-warnings';
+    protected $description = 'Wyślij powiadomienie email, gdy temperatura spadnie poniżej progu użytkownika';
+
+    public function handle(ImgwApiClient $client)
+    {
+        $meteoData = $client->getMeteoData();
+
+        User::with('preference')
+            ->whereHas('preference', fn($q) => $q->where('temperature_warning', true))
+            ->get()
+            ->each(function($user) use ($meteoData) {
+                $pref  = $user->preference;
+                $city  = mb_strtolower($pref->city);
+                $limit = (float) $pref->temperature_check_value;
+
+                $entry = collect($meteoData)
+                    ->first(fn($d) => mb_strtolower($d['city']) === $city);
+
+                if (! $entry) {
+                    return;
+                }
+
+                $current = $entry['temp'];
+
+                if ($current < $limit) {
+                    SendMail::sendMail(
+                        $user->email,
+                        $user->id,
+                        'temp_warning',
+                        [
+                            'city'    => $pref->city,
+                            'current' => $current,
+                            'value'   => $limit,
+                        ]
+                    );
+                }
+            });
+
+        $this->info('Sprawdzono ostrzeżenia temperaturowe.');
+    }
+}

--- a/app/Console/Commands/SendWarningsEmails.php
+++ b/app/Console/Commands/SendWarningsEmails.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Services\ImgwApiClient;
+use App\Models\User;
+use App\Mail\SendMail;
+
+class SendWarningsEmails extends Command
+{
+    protected $signature = 'send:warnings-emails';
+    protected $description = 'Wyślij ostrzeżenia meteorologiczne i hydrologiczne na maile użytkowników';
+
+    public function handle(ImgwApiClient $client)
+    {
+        $meteo = $client->getWarningsMeteo();
+        $hydro = $client->getWarningsHydro();
+
+        User::with('preference')
+            ->where('email_verified_at', '!=', null)
+            ->get()
+            ->each(function (User $user) use ($meteo, $hydro) {
+                $pref = $user->preference;
+                if ($pref->notice_method !== 'email') {
+                    return;
+                }
+
+                // ostrzeżenia meteo
+                if ($pref->meteorological_warnings) {
+                    $userCity = $pref->city;
+                    $userMeteo = array_filter($meteo, fn($w) => in_array($userCity, $w['area']));
+                    if (count($userMeteo)) {
+                        SendMail::sendMail(
+                            $user->email,
+                            $user->id,
+                            'warnings_meteo',
+                            $userMeteo
+                        );
+                    }
+                }
+
+                // ostrzeżenia hydro
+                if ($pref->hydrological_warnings) {
+                    $userCity = $pref->city;
+                    $userHydro = array_filter($hydro, fn($w) => in_array($userCity, $w['area']));
+                    if (count($userHydro)) {
+                        SendMail::sendMail(
+                            $user->email,
+                            $user->id,
+                            'warnings_hydro',
+                            $userHydro
+                        );
+                    }
+                }
+            });
+
+        $this->info('Wysłano wszystkie e-maile z ostrzeżeniami.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    /**
+     * Tutaj rejestrujesz własne komendy Artisan.
+     */
+    protected $commands = [
+        // Komenda do wysyłki ostrzeżeń meteorologicznych i hydrologicznych
+        \App\Console\Commands\SendWarningsEmails::class,
+        // Komenda do sprawdzania i wysyłki ostrzeżeń temperaturowych
+        \App\Console\Commands\CheckTemperatureAlerts::class,
+    ];
+
+    /**
+     * Schedule your commands here.
+     */
+    protected function schedule(Schedule $schedule): void
+    {
+        // Ostrzeżenia meteorologiczne i hydrologiczne co 30 minut
+        $schedule->command('send:warnings-emails')
+            ->cron('*/30 * * * *')
+            ->timezone('Europe/Warsaw');
+
+        // Ostrzeżenia temperaturowe co 30 minut
+        $schedule->command('check:temp-warnings')
+            ->cron('*/30 * * * *')
+            ->timezone('Europe/Warsaw');
+    }
+
+    /**
+     * Register the commands for the application.
+     */
+    protected function commands(): void
+    {
+        // Auto‐discovery katalogu Commands
+        $this->load(__DIR__ . '/Commands');
+    }
+}

--- a/app/Http/Controllers/AddressSuggestionController.php
+++ b/app/Http/Controllers/AddressSuggestionController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class AddressSuggestionController extends Controller
+{
+    /**
+     * GET /api/addresses/suggest?q=ciąg
+     * Zwraca top 10 miast (kolumna `city`) z tabeli air_pollution_leaderboard
+     * posortowane po odległości Levenshteina od q.
+     */
+    public function suggest(Request $request)
+    {
+        $q = trim((string) $request->query('q', ''));
+        if ($q === '') {
+            return response()->json(['suggestions' => []]);
+        }
+
+        $candidates = DB::table('air_pollution_leaderboard')
+            ->select('city as address')
+            ->whereRaw('LOWER(city) LIKE ?', ['%' . strtolower($q) . '%'])
+            ->distinct()
+            ->limit(50)
+            ->pluck('address')
+            ->all();
+
+        $scored = array_map(function(string $addr) use ($q) {
+            return [
+                'address'  => $addr,
+                'distance' => levenshtein(mb_strtolower($q), mb_strtolower($addr)),
+            ];
+        }, $candidates);
+
+        usort($scored, fn($a, $b) => $a['distance'] <=> $b['distance']);
+
+
+        $suggestions = array_slice(
+            array_column($scored, 'address'),
+            0,
+            10
+        );
+
+        return response()->json(['suggestions' => $suggestions]);
+    }
+}

--- a/app/Http/Controllers/Auth/EmailUpdateController.php
+++ b/app/Http/Controllers/Auth/EmailUpdateController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Mail\SendMail;
+
+class EmailUpdateController extends Controller
+{
+    /**
+     * Zmienia email użytkownika, czyści email_verified_at i wysyła link weryfikacyjny.
+     */
+    public function update(Request $request)
+    {
+        $request->validate([
+            'email' => 'required|email|unique:users,email',
+        ]);
+
+        /** @var \App\Models\User $user */
+        $user = Auth::user();  // dzięki PHPDoc wiemy, że to nie jest null
+
+        // 1) Podmień email i wyczyść flagę weryfikacji:
+        $user->forceFill([
+            'email'             => $request->input('email'),
+            'email_verified_at' => null,
+        ])->save();
+
+        // 2) Wyślij link weryfikacyjny na nowy email:
+        SendMail::sendMail(
+            $user->email,
+            $user->id,
+            'emailverify'
+        );
+
+        return response()->json([
+            'message' => 'E-mail został zaktualizowany, wysłaliśmy link weryfikacyjny.',
+        ], 200);
+    }
+}

--- a/app/Http/Requests/GetAirQualityRequest.php
+++ b/app/Http/Requests/GetAirQualityRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\DB;
 
 class GetAirQualityRequest extends FormRequest
 {
@@ -16,25 +17,64 @@ class GetAirQualityRequest extends FormRequest
 
     /**
      * Get the validation rules that apply to the request.
-     *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
         return [
-            'lat' => 'required|numeric|between:49.0,55.0', // Poland
-            'lon' => 'required|numeric|between:14.0,24.0',
+            'lat'  => 'required_without:addr|numeric|between:49.0,55.0', // Poland latitude range
+            'lon'  => 'required_without:addr|numeric|between:14.0,24.0', // Poland longitude range
+            'addr' => 'required_without_all:lat,lon|string',
         ];
     }
+
     /**
-     * @return array<int,float>
+     * Return coordinates: either rounded lat/lon or resolved from addr.
+     * @return array{0: float, 1: float}
+     * @throws \RuntimeException if no matching location found.
      */
     public function coordinates(): array
     {
-        // Round here once for cache‐key consistency
-        return [
-            round($this->input('lat'), 3),
-            round($this->input('lon'), 3),
-        ];
+        // If lat and lon provided, use them (rounded for cache consistency)
+        if ($this->filled(['lat', 'lon'])) {
+            return [
+                round($this->input('lat'), 3),
+                round($this->input('lon'), 3),
+            ];
+        }
+
+        // Otherwise, resolve from address fuzzy match
+        $query = mb_strtolower($this->input('addr'));
+
+        // Perform case-insensitive LIKE search, take distinct stations
+        $candidates = DB::table('air_pollution_historical_data')
+            ->select('station_name', 'latitude', 'longitude')
+            ->whereRaw('LOWER(station_name) LIKE ?', ["%{$query}%"])
+            ->distinct()
+            ->limit(50)
+            ->get()
+            ->map(function($row) {
+                return [
+                    'label'     => $row->station_name,
+                    'latitude'  => (float) $row->latitude,
+                    'longitude' => (float) $row->longitude,
+                ];
+            })
+            ->all();
+
+        if (empty($candidates)) {
+            throw new \RuntimeException("Nie znaleziono lokalizacji podobnej do \"{$this->input('addr')}\"");
+        }
+
+        // Compute Levenshtein distances
+        $distances = array_map(
+            fn($item) => levenshtein($query, mb_strtolower($item['label'])),
+            $candidates
+        );
+
+        // Pick best match
+        $minIndex = array_keys($distances, min($distances))[0];
+        $best     = $candidates[$minIndex];
+
+        return [ $best['latitude'], $best['longitude'] ];
     }
 }

--- a/docs/api/addresses_endpoints.yml
+++ b/docs/api/addresses_endpoints.yml
@@ -1,0 +1,108 @@
+openapi: 3.0.3
+info:
+  title: Address Suggestions API
+  description: >
+    Endpoint for retrieving fuzzy‑matched location name suggestions
+    based on a partial query string.
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+    description: Main API server
+tags:
+  - name: Addresses
+    description: Suggestion endpoints for locations
+
+paths:
+  /addresses/suggest:
+    get:
+      summary: Suggest available location names
+      description: >
+        Returns up to 10 suggested station or city names based on a fuzzy match
+        of the supplied partial query string. Useful for autocompletion.
+      operationId: suggestAddresses
+      tags:
+        - Addresses
+      parameters:
+        - name: q
+          in: query
+          description: Partial name fragment of the city or station
+          required: true
+          schema:
+            type: string
+            example: "warsz"
+      responses:
+        "200":
+          description: A list of suggested names
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  suggestions:
+                    type: array
+                    description: Array of matching location names
+                    items:
+                      type: string
+                    example:
+                      - "Warszawa-Centrum"
+                      - "Warszawa-Wawer"
+        "400":
+          description: Validation error (missing or invalid `q`)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse422"
+        "401":
+          description: Unauthorized (if protected by auth)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse401"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+components:
+  schemas:
+    ErrorResponse401:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: "Unauthorized"
+    ErrorResponse422:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: "Validation error"
+        errors:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            q:
+              - "The q field is required."
+    ErrorResponse500:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: "Server error"
+        error:
+          type: string
+          example: "Exception details"

--- a/docs/api/air_quality_endpoints.yml
+++ b/docs/api/air_quality_endpoints.yml
@@ -11,6 +11,9 @@ servers:
 tags:
   - name: Air Quality
     description: Operations related to air quality data
+  - name: Addresses
+    description: Suggestion endpoints
+
 paths:
   /air-quality:
     get:
@@ -18,15 +21,15 @@ paths:
       description: |
         Returns detailed air quality information for a specific location in Poland,
         including measurements from the nearest monitoring station, air quality index,
-        and forecasts if available.
-      operationId: __invoke
+        and forecasts if available. You may specify either `lat`/`lon` **or** `addr`.
+      operationId: getAirQuality
       tags:
         - Air Quality
       parameters:
         - name: lat
           in: query
-          description: Latitude coordinate (must be within Poland's range)
-          required: true
+          description: Latitude coordinate (must be within Poland's range; required if `addr` is not provided)
+          required: false
           schema:
             type: number
             format: float
@@ -35,14 +38,21 @@ paths:
             example: 52.2297
         - name: lon
           in: query
-          description: Longitude coordinate (must be within Poland's range)
-          required: true
+          description: Longitude coordinate (must be within Poland's range; required if `addr` is not provided)
+          required: false
           schema:
             type: number
             format: float
             minimum: 14.0
             maximum: 24.0
             example: 21.0122
+        - name: addr
+          in: query
+          description: Fuzzy name of the city/station—required if `lat`/`lon` are not provided
+          required: false
+          schema:
+            type: string
+            example: "Szczecin Żołnierska"
       responses:
         "200":
           description: Successful operation
@@ -50,27 +60,78 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AirQualityResponse"
-        "404":
-          description: No measuring stations found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse404"
-        "422":
-          description: Validation error
+        "400":
+          description: Validation error (must supply either lat+lon or addr)
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse422"
+        "404":
+          description: No measuring stations or no matching location found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse404"
         "500":
           description: Server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse500"
+      # Custom validation rule: require either (lat and lon) OR addr
+      x-validator:
+        anyOf:
+          - required: [lat, lon]
+          - required: [addr]
+
+  /addresses/suggest:
+    get:
+      summary: Suggest available locations by partial query
+      description: |
+        Returns up to 10 suggested station names based on a fuzzy match
+        of the supplied query string.
+      operationId: suggestAddresses
+      tags:
+        - Addresses
+      parameters:
+        - name: q
+          in: query
+          description: Partial name of the city or station
+          required: true
+          schema:
+            type: string
+            example: "warsz"
+      responses:
+        "200":
+          description: List of suggested location names
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  suggestions:
+                    type: array
+                    items:
+                      type: string
+                    example:
+                      - "Warszawa-Centrum"
+                      - "Warszawa-Wawer"
+        "401":
+          description: Unauthorized (if endpoint is protected)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse401"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
 components:
   schemas:
-    AirQualityResponse:
+    AirQualityResponse:       # unchanged...
       type: object
       properties:
         success:
@@ -94,111 +155,8 @@ components:
         data:
           type: object
           properties:
-            station:
-              type: object
-              properties:
-                id:
-                  type: integer
-                  example: 123
-                name:
-                  type: string
-                  example: "Warszawa-Centrum"
-                latitude:
-                  type: string
-                  example: "52.2258"
-                longitude:
-                  type: string
-                  example: "21.0095"
-                distance:
-                  type: string
-                  example: "0.45 km"
-                address:
-                  type: string
-                  nullable: true
-                  example: "ul. Marszałkowska 1"
-                city:
-                  type: string
-                  nullable: true
-                  example: "Warszawa"
-                commune:
-                  type: string
-                  nullable: true
-                  example: "Warszawa"
-                district:
-                  type: string
-                  nullable: true
-                  example: "Warszawa"
-                province:
-                  type: string
-                  nullable: true
-                  example: "MAZOWIECKIE"
-            airQuality:
-              type: object
-              nullable: true
-              properties:
-                index:
-                  type: string
-                  example: "Dobry"
-                calculationTime:
-                  type: string
-                  format: date-time
-                  nullable: true
-                  example: "2025-03-25 10:00:00"
-                sourceDataTime:
-                  type: string
-                  format: date-time
-                  nullable: true
-                  example: "2025-03-25 10:00:00"
-                pollutants:
-                  type: object
-                  additionalProperties:
-                    type: object
-                    properties:
-                      index:
-                        type: string
-                        example: "Dobry"
-                      calculationTime:
-                        type: string
-                        format: date-time
-                        nullable: true
-                        example: "2025-03-25 10:00:00"
-            measurements:
-              type: array
-              items:
-                type: object
-                properties:
-                  parameter:
-                    type: string
-                    example: "pył zawieszony PM10"
-                  code:
-                    type: string
-                    example: "PM10"
-                  value:
-                    type: number
-                    format: float
-                    example: 24.5
-                  unit:
-                    type: string
-                    example: "µg/m³"
-                  measurementTime:
-                    type: string
-                    format: date-time
-                    example: "2025-03-25 10:00:00"
-            forecasts:
-              type: object
-              additionalProperties:
-                type: object
-                additionalProperties:
-                  type: number
-                  format: float
-              example:
-                PM10:
-                  "20250325": 18.45
-                  "20250326": 21.32
-                NO2:
-                  "20250325": 32.1
-                  "20250326": 29.4
-    ErrorResponse404:
+          # ... existing station, airQuality, measurements, forecasts ...
+    ErrorResponse404:         # unchanged...
       type: object
       properties:
         success:
@@ -207,7 +165,7 @@ components:
         message:
           type: string
           example: "No measuring stations found"
-    ErrorResponse422:
+    ErrorResponse422:         # renamed from 400 to 422
       type: object
       properties:
         success:
@@ -224,9 +182,8 @@ components:
               type: string
           example:
             lat:
-              - "The lat field is required."
-              - "The lat must be between 49 and 55."
-    ErrorResponse500:
+              - "The lat field is required when addr is not present."
+    ErrorResponse500:         # unchanged...
       type: object
       properties:
         success:
@@ -238,3 +195,12 @@ components:
         error:
           type: string
           example: "Error message details"
+    ErrorResponse401:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: "Unauthorized"

--- a/docs/api/email_endpoints.yml
+++ b/docs/api/email_endpoints.yml
@@ -1,0 +1,112 @@
+openapi: 3.0.3
+info:
+  title: User Email Update API
+  description: >
+    Endpoint for authenticated users to update their email address.
+    Clears the old verification flag and sends a new verification link.
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+    description: Main API server
+tags:
+  - name: User
+    description: Operations related to the authenticated user
+
+paths:
+  /user/email:
+    patch:
+      summary: Update user email address
+      description: >
+        Allows a logged‑in user to change their email. The old
+        `email_verified_at` timestamp is cleared, and a new
+        verification link is sent to the new address.
+      operationId: updateUserEmail
+      tags:
+        - User
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  description: New email address (must be unique)
+                  example: "newuser@example.com"
+              required:
+                - email
+      responses:
+        "200":
+          description: Email updated and verification link sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "E-mail został zaktualizowany, wysłaliśmy link weryfikacyjny."
+        "401":
+          description: Unauthorized (user not logged in)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse401"
+        "422":
+          description: Validation error (invalid or non‐unique email)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse422"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    ErrorResponse401:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Unauthenticated."
+    ErrorResponse422:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: "The given data was invalid."
+        errors:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            email:
+              - "The email has already been taken."
+    ErrorResponse500:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Server error"
+        error:
+          type: string
+          example: "Detailed exception message"

--- a/resources/js/api/addressApi.ts
+++ b/resources/js/api/addressApi.ts
@@ -1,0 +1,29 @@
+import { instance, Payload } from "./api";
+
+export interface SuggestAddressesResponse {
+    suggestions: string[];
+}
+
+export const suggestAddresses = async (
+    payload: Payload & { q: string }
+): Promise<SuggestAddressesResponse | null> => {
+    const { token, q } = payload;
+    if (!token) {
+        console.error("Token is empty.");
+        return null;
+    }
+    try {
+        const res = await instance.get<SuggestAddressesResponse>(
+            "/addresses/suggest",
+            {
+                params: { q },
+                headers: { Authorization: `Bearer ${token}` },
+            }
+        );
+        return res.data;
+    } catch (error: unknown) {
+        if (error instanceof Error) console.error(error.message);
+        else console.error("Unknown error fetching address suggestions");
+        return null;
+    }
+};

--- a/resources/js/api/emailApi.ts
+++ b/resources/js/api/emailApi.ts
@@ -1,0 +1,56 @@
+// resources/js/api/emailApi.ts
+import { instance, Payload } from "./api";
+
+export interface UpdateEmailPayload {
+    email: string;
+}
+
+export interface UpdateEmailResponse {
+    message: string;
+}
+
+export const updateEmail = async (
+    payload: Payload & UpdateEmailPayload
+): Promise<UpdateEmailResponse | null> => {
+    const { token, email } = payload;
+    if (!token) {
+        console.error("Token is empty.");
+        return null;
+    }
+    try {
+        const res = await instance.post<UpdateEmailResponse>(
+            "/user/email",
+            { email },
+            { headers: { Authorization: `Bearer ${token}` } }
+        );
+        return res.data;
+    } catch (e: unknown) {
+        console.error(e);
+        return null;
+    }
+};
+
+export interface ResendVerificationResponse {
+    message: string;
+}
+
+export const resendVerificationEmail = async (
+    payload: Payload
+): Promise<ResendVerificationResponse | null> => {
+    const { token } = payload;
+    if (!token) {
+        console.error("Token is empty.");
+        return null;
+    }
+    try {
+        const res = await instance.post<ResendVerificationResponse>(
+            "/email/verification-notification",
+            {},
+            { headers: { Authorization: `Bearer ${token}` } }
+        );
+        return res.data;
+    } catch (e: unknown) {
+        console.error(e);
+        return null;
+    }
+};

--- a/resources/views/emails/temp_warning.blade.php
+++ b/resources/views/emails/temp_warning.blade.php
@@ -1,0 +1,12 @@
+@component('mail::message')
+    # Ostrzeżenie temperaturowe
+
+    Temperatura w **{{ $data['city'] }}** spadła do **{{ $data['current'] }}°C**,
+    co jest poniżej Twojego ustawionego progu **{{ $data['value'] }}°C**.
+
+    Jeśli chcesz zmienić próg ostrzeżeń, odwiedź ustawienia konta.
+
+    ---
+    Bezpiecznego dnia,
+    Zespół IPZ
+@endcomponent

--- a/resources/views/emails/warnings.blade.php
+++ b/resources/views/emails/warnings.blade.php
@@ -1,0 +1,20 @@
+@component('mail::message')
+    # Ostrzeżenia dla Twojej lokalizacji
+
+    {{ $data['msg'] }}
+
+    @foreach($data['items'] as $warning)
+        - **{{ ucfirst($warning['phenomenon']) }}** (poziom {{ $warning['level'] }})
+
+        _Od:_ {{ \Illuminate\Support\Carbon::parse($warning['start'])->toDayDateTimeString() }}
+        _Do:_ {{ \Illuminate\Support\Carbon::parse($warning['end'])->toDayDateTimeString() }}
+        _Obszar:_ {{ implode(', ', $warning['area']) }}
+
+    @endforeach
+
+    ---
+    Jeśli chcesz zobaczyć więcej szczegółów, odwiedź naszą stronę.
+
+    Pozdrawiamy,
+    Zespół IPZ
+@endcomponent

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,10 @@ use App\Http\Middleware\CheckUserBlocked;
 use App\Http\Middleware\EnsureUserIsVerified;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AddressSuggestionController;
+
+Route::get('/addresses/suggest', [AddressSuggestionController::class, 'suggest'])
+    ->name('addresses.suggest');
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Auth\EmailUpdateController;
 
 Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])
@@ -45,6 +46,9 @@ Route::middleware('auth')->group(function () {
     Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
         ->middleware('throttle:6,1')
         ->name('verification.send');
+
+    Route::post('user/email', [EmailUpdateController::class, 'update'])
+        ->name('user.email.update');
 
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
         ->name('password.confirm');

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use App\Mail\SendMail;
+use App\Http\Controllers\Auth\EmailUpdateController;
 
 Route::get('/login', function() {
     return Inertia::render('login');
@@ -31,6 +32,9 @@ Route::get('/idkfa', function () {
 Route::get('/email/verify/{id}/{hash}', [\App\Http\Controllers\Auth\VerifyEmailController::class, '__invoke'])
 	//->middleware(['signed', 'throttle:6,1'])
 	->name('verification.verify');
+
+Route::post('/user/email', [EmailUpdateController::class, 'update'])
+    ->name('user.email.update');
 
 Route::get('/email/verify/thank-you', function () {
 	return Inertia::render('pages/VerifyEmailThankYou');


### PR DESCRIPTION
Description:
What does this PR do?
Rozszerza endpoint /api/air-quality, aby akceptował zarówno parametry lat/lon, jak i addr. Jeśli użytkownik poda addr, wykonuje fuzzy‐match w tabeli air_pollution_historical_data na polu station_name i pobiera z niej współrzędne.

Dodaje nowy endpoint /api/addresses/suggest, który na podstawie fragmentu wpisanego adresu zwraca listę do 10 podpowiedzi z tabeli air_pollution_historical_data, posortowanych po odległości Levenshteina.

Modyfikuje klasę GetAirQualityRequest, aby walidować parametr addr i implementować powyższą logikę fuzzy‐match.

Rozszerza klasę SendMail o nowe typy wiadomości: warnings_meteo, warnings_hydro oraz temp_warning, dopasowując payload i widoki Blade (emails.warnings.blade.php, emails.temp_warning.blade.php).

Dodaje konsolowe komendy Artisan:

send:warnings-emails (wysyła ostrzeżenia meteorologiczne i hydrologiczne co 30 min),

check:temp-warnings (sprawdza temperaturę wg progów użytkowników i wysyła e‑mail ostrzegawczy).

Konfiguruje Scheduler (schedule:work) i Supervisor, aby te komendy działały w tle i restartowały się po deployu.

Why is this change necessary?
Umożliwia użytkownikom korzystanie z ludzkich nazw lokalizacji zamiast tylko współrzędnych.

Poprawia UX dzięki autosugestiom adresów przy wyszukiwarce miast.

Automatyzuje wysyłanie ostrzeżeń oraz alarmów temperaturowych, zgodnie z preferencjami użytkowników.

What issues does this PR fix/close?
Zamyka potrzeby #139 (ostrzeżenia meteorologiczne i hydrologiczne),

Wprowadza funkcjonalność #… (fuzzy‐match dla /air-quality?addr=),

Realizuje #… (autosugestie adresów).


Are there any known issues or edge cases?
W niektórych rzadkich lokalizacjach może zabraknąć wpisu w historical_data i rzuci się RuntimeException. Można to obsłużyć dodając fallback do najbliższych współrzędnych.

Wysoka liczba ostrzeżeń (items > 20) może spowodować długi e‑mail — ewentualnie ograniczyć liczbę w payloadzie.
