### PR TITLE
add confirmation and reset password mail types

### DIFF
--- a/resources/views/emails/confirmation.blade.php
+++ b/resources/views/emails/confirmation.blade.php
@@ -1,0 +1,98 @@
+@if(isset($data['verify_link']))
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <title>Weryfikacja adresu e-mail</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', sans-serif;
+            background-color: #f0f4f8;
+            padding: 20px;
+            color: #333;
+        }
+        .card {
+            max-width: 600px;
+            background: #fff;
+            margin: auto;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            padding: 30px;
+        }
+        h1 {
+            color: #2c7be5;
+            font-size: 22px;
+            text-align: center;
+        }
+        .icon {
+            text-align: center;
+            font-size: 40px;
+            margin-bottom: 10px;
+        }
+        .btn {
+            display: inline-block;
+            padding: 12px 25px;
+            background: linear-gradient(to right, #00b4db, #0083b0);
+            color: white;
+            border-radius: 25px;
+            text-decoration: none;
+            margin: 20px 0;
+            font-weight: bold;
+        }
+        .highlight {
+            background: #fdf3d8;
+            border-left: 4px solid #f9ca24;
+            padding: 10px;
+            margin-top: 20px;
+        }
+        .footer {
+            font-size: 12px;
+            color: #888;
+            text-align: center;
+            margin-top: 30px;
+        }
+    </style>
+</head>
+<body>
+<div class="card">
+    <div class="icon">📬</div>
+    <h1>Weryfikacja Adresu E-mail</h1>
+
+    <p>Cześć!</p>
+    <p>Dziękujemy za rejestrację. Aby dokończyć proces i uzyskać pełny dostęp do konta, potwierdź swój adres e-mail klikając poniżej:</p>
+
+    <p style="text-align:center;">
+        <a href="{{ $data['verify_link'] ?? '#' }}" class="btn">Zweryfikuj E-mail</a>
+    </p>
+
+    <div class="highlight">
+        <strong>Ważne:</strong> Link weryfikacyjny wygaśnie w ciągu 24 godzin. Możesz wygenerować nowy link w ustawieniach konta.
+    </div>
+
+    <p style="margin-top: 20px;">
+        Jeśli to nie Ty utworzyłeś konto, zignoruj tę wiadomość – prawdopodobnie ktoś wpisał błędnie adres e-mail.
+    </p>
+
+    <div class="footer">
+    Z poważaniem,<br>
+    Zespół ZUT Weather<br>
+    <br>
+    Tworząc konto, akceptujesz politykę prywatności i zasady RODO</a>.<br>
+    © 2025 ZUT Weather. Wszelkie prawa zastrzeżone.
+</div>
+</div>
+</body>
+</html>
+
+@else
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <title>Ogólne Powiadomienie</title>
+</head>
+<body>
+    <p>{{ $data['msg'] ?? 'Brak treści wiadomości.' }}</p>
+</body>
+</html>
+@endif

--- a/resources/views/emails/resetpwd.blade.php
+++ b/resources/views/emails/resetpwd.blade.php
@@ -1,0 +1,97 @@
+@if(isset($data['reset_link']) && isset($data['username']))
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <title>Resetowanie Hasła</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', sans-serif;
+            background-color: #f0f4f8;
+            padding: 20px;
+            color: #333;
+        }
+        .card {
+            max-width: 600px;
+            background: #fff;
+            margin: auto;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            padding: 30px;
+        }
+        h1 {
+            color: #2c7be5;
+            font-size: 22px;
+            text-align: center;
+        }
+        .icon {
+            text-align: center;
+            font-size: 40px;
+            margin-bottom: 10px;
+        }
+        .btn {
+            display: inline-block;
+            padding: 12px 25px;
+            background: linear-gradient(to right, #00b4db, #0083b0);
+            color: white;
+            border-radius: 25px;
+            text-decoration: none;
+            margin: 20px 0;
+            font-weight: bold;
+        }
+        .highlight {
+            background: #fdf3d8;
+            border-left: 4px solid #f9ca24;
+            padding: 10px;
+            margin-top: 20px;
+        }
+        .footer {
+            font-size: 12px;
+            color: #888;
+            text-align: center;
+            margin-top: 30px;
+        }
+    </style>
+</head>
+<body>
+<div class="card">
+    <div class="icon">🔐</div>
+    <h1>Resetowanie Hasła</h1>
+
+    <p>Cześć {{ $data['username'] }},</p>
+    <p>Wygląda na to, że ktoś (może Ty?) poprosił o zresetowanie hasła.</p>
+    <p>Aby ustawić nowe hasło, kliknij poniższy link:</p>
+
+    <p style="text-align:center;">
+        <a href="{{ $data['reset_link'] }}" class="btn">Resetuj Hasło</a>
+    </p>
+
+    <div class="highlight">
+        <strong>Uwaga:</strong> Link do resetowania hasła wygaśnie po 60 minutach. Jeśli link wygaśnie, możesz ponownie poprosić o resetowanie hasła.
+    </div>
+
+    <p style="margin-top: 20px;">
+        Jeśli nie prosiłeś(-aś) o zmianę hasła, zignoruj tę wiadomość lub skontaktuj się z naszym wsparciem technicznym.
+    </p>
+
+    <div class="footer">
+        Z poważaniem,<br>
+        Zespół ZUT Weather<br>
+        © 2025 ZUT Weather. Wszelkie prawa zastrzeżone.
+    </div>
+</div>
+</body>
+</html>
+
+@else
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <title>Ogólne Powiadomienie</title>
+</head>
+<body>
+    <p>{{ $data['msg'] ?? 'Brak treści wiadomości.' }}</p>
+</body>
+</html>
+@endif


### PR DESCRIPTION
## Description:
Add separate return statements and views for mail types in SendMail

### What does this PR do?

This PR refactors the `SendMail` Mailable class to use separate return statements for each mail type. It also assigns different Blade views to each mail type (`emailverify`, `resetpassword`, `default`) to improve code clarity and maintainability.

### Why is this change necessary?

Previously, all mail types were handled by a single view with conditional statements inside the Blade template. This change allows each mail type to have its own dedicated view, making templates easier to manage, extend, and test.

### What issues does this PR fix/close?

No specific issue number – improves maintainability and separation of concerns in mailing logic.

## Testing:

### How was this PR tested?

- Manual testing: sent test emails for `resetpassword` and `emailverify` mail types using `SendMail::sendMail(...)`.
- Verified that each mail type uses the correct Blade view and includes the expected data in the email.
- Checked rendered emails in browser/mail client.
- Confirmed no breaking changes in email sending flow.

### Are there any known issues or edge cases?

None known at this time.

## Checklist:

- [x] Code is formatted correctly.
- [x] Documentation is updated (if necessary).
- [x] Changelog is updated (if necessary).
- [x] All new and existing tests passed (if applicable).