### PR TITLE
feat(frontend): allow toggling temperature between Celsius and Fahrenheit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,5 +22,5 @@ indent_size = 2
 max_line_length = 80
 shell_variant = posix
 
-[*.yml]
+[*.{yml,js,ts,tsx}]
 indent_size = 2

--- a/resources/js/pages/dashboard/WeatherCard.tsx
+++ b/resources/js/pages/dashboard/WeatherCard.tsx
@@ -55,11 +55,18 @@ export function WeatherCard({
           <Typography>Loading...</Typography>
         ) : (
           <Box mt={2} textAlign="center">
-            <div onClick={toggleUnit}>
+            <button
+              onClick={toggleUnit}
+              aria-label="Toggle temperature unit"
+              style={{
+                all: "unset",
+                cursor: "pointer",
+                display: "inline-block",
+              }}>
               <Typography variant="h4">
                 🌤 {temperature}°{unit === Unit.Celsius ? "C" : "F"}
               </Typography>
-            </div>
+            </button>
             <Typography>💧 {weather.relative_humidity}%</Typography>
             <Typography>💨 {weather.wind_speed} m/s</Typography>
             <Typography>🌡 {weather.pressure} hPa</Typography>

--- a/resources/js/pages/dashboard/WeatherCard.tsx
+++ b/resources/js/pages/dashboard/WeatherCard.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { Card, CardContent, Typography, Box } from "@mui/material";
 import { SynopResponse } from "@/api/synopApi";
+import { useEffect, useState } from "react";
 
 interface Props {
   city: string;
@@ -9,12 +9,37 @@ interface Props {
   loading: boolean;
 }
 
-export const WeatherCard: React.FC<Props> = ({
+enum Unit {
+  Celsius,
+  Fahrenheit,
+}
+
+export function WeatherCard({
   city,
   dateStr,
   weather,
   loading,
-}) => {
+}: Props): JSX.Element {
+  const [temperature, setTemperature] = useState<number>(
+    weather?.temperature ?? 0,
+  );
+  const [unit, setUnit] = useState<Unit>(Unit.Celsius);
+
+  const toggleUnit = () => {
+    setUnit(unit === Unit.Celsius ? Unit.Fahrenheit : Unit.Celsius);
+  };
+
+  useEffect(() => {
+    switch (unit) {
+      case Unit.Celsius:
+        setTemperature(weather?.temperature ?? 0);
+        break;
+      case Unit.Fahrenheit:
+        setTemperature((weather?.temperature ?? 0) * 1.8 + 32);
+        break;
+    }
+  }, [weather?.temperature, unit]);
+
   return (
     <Card
       sx={{
@@ -30,7 +55,11 @@ export const WeatherCard: React.FC<Props> = ({
           <Typography>Loading...</Typography>
         ) : (
           <Box mt={2} textAlign="center">
-            <Typography variant="h4">🌤 {weather.temperature}°C</Typography>
+            <div onClick={toggleUnit}>
+              <Typography variant="h4">
+                🌤 {temperature}°{unit === Unit.Celsius ? "C" : "F"}
+              </Typography>
+            </div>
             <Typography>💧 {weather.relative_humidity}%</Typography>
             <Typography>💨 {weather.wind_speed} m/s</Typography>
             <Typography>🌡 {weather.pressure} hPa</Typography>
@@ -39,4 +68,4 @@ export const WeatherCard: React.FC<Props> = ({
       </CardContent>
     </Card>
   );
-};
+}


### PR DESCRIPTION
Close #197


Domyślnie Celsius:
![image](https://github.com/user-attachments/assets/eebc0851-c35e-4550-bec5-698345569180)

Po kliknięcie przełącza na Fahrenheit lub z powrotem na Celsius:
![image](https://github.com/user-attachments/assets/e2e811be-d795-41a0-b01e-1f72a817b355)


