### PR TITLE
feat(frontend): create error boundary

### DIFF
--- a/resources/js/components/ErrorBoundary.tsx
+++ b/resources/js/components/ErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import React, { ErrorInfo, ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p>Something went wrong (see console).</p>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/resources/js/pages/dashboard/Dashboard.tsx
+++ b/resources/js/pages/dashboard/Dashboard.tsx
@@ -9,6 +9,7 @@ import { WeatherCard } from "./WeatherCard";
 import { AirPollutionChart } from "./AirPollutionChart";
 import { CityMap } from "./CityMap";
 import { LatLng } from "leaflet";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 export const Dashboard: React.FC = () => {
   const [searchValue, setSearchValue] = React.useState("");
@@ -114,15 +115,17 @@ export const Dashboard: React.FC = () => {
                 borderRadius: 2,
               }}>
               <CardContent>
-                <AirPollutionChart measurements={airData?.measurements} />
+                <ErrorBoundary>
+                  <AirPollutionChart measurements={airData?.measurements} />
+                </ErrorBoundary>
               </CardContent>
             </Card>
           </Grid>
           {/* Map */}
           <Grid item xs={12} md={6}>
-          <Card sx={{ height: 400, borderRadius: 2, boxShadow: 3 }}>
-            <CityMap coords={getCoords()} city={city} />
-          </Card>
+            <Card sx={{ height: 400, borderRadius: 2, boxShadow: 3 }}>
+              <CityMap coords={getCoords()} city={city} />
+            </Card>
           </Grid>
         </Grid>
       </Box>


### PR DESCRIPTION
Dodaje komponent `ErrorBoundary`, który można wykorzystać do owinięcia nim problematycznych komponentów.

Wykorzystuję go w `Dashboard`, do owinięcia `AirPollutionChart`, aby w przypadku wyjątku nie crashował całej aplikacji.